### PR TITLE
Changes workout specification to limit max_speed

### DIFF
--- a/app/services/activity_service.rb
+++ b/app/services/activity_service.rb
@@ -18,7 +18,7 @@ class ActivityService
   end
 
   def workout_specifications(activity)
-    (activity["type"] == "Run" && activity["average_speed"] != 0.0) 
+    (activity["type"] == "Run" && activity["max_speed"] != 0.0) 
   end
 
   def count_activity_services


### PR DESCRIPTION
- See previous commit for justification
- Max speed is a superior limitation due to the fact that users can manually log workouts with a distance an a time, thereby calculating an average_speed. However, max speed is set to 0.0 for these workouts, thus they can be removed.
- Still need model test